### PR TITLE
Fix module path for zsh modules

### DIFF
--- a/modules/zinit.zsh
+++ b/modules/zinit.zsh
@@ -32,6 +32,12 @@ fi
 
 # Set the module path for zsh to find modules correctly
 export ZMODULE_PATH="$ZSH_MODULE_PATH/zsh"
+# Ensure the system module path is included so plugins like
+# fast-syntax-highlighting can load modules such as zsh/termcap
+# without specifying the directory explicitly.
+if [[ -d "$ZMODULE_PATH" ]]; then
+    [[ "${module_path:-}" != *"$ZMODULE_PATH"* ]] && module_path=("$ZMODULE_PATH" $module_path)
+fi
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- fix module path handling for zsh module loading in zinit module

## Testing
- `zsh -c 'source zshrc; run_zsh_tests'` *(fails: `zsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864a7cf2d7c832b85937d12be786bda