### PR TITLE
Fix candidate completion in modules/completion.zsh

### DIFF
--- a/modules/completion.zsh
+++ b/modules/completion.zsh
@@ -87,7 +87,10 @@ fi
 bindkey '^I' complete-word
 bindkey '^[[Z' reverse-menu-complete
 zstyle ':completion:*' accept-exact '*(N)'
-zstyle ':completion:*' insert-tab pending
+# Show completions immediately instead of inserting a literal tab on the first
+# press. This avoids confusion where pressing Tab appears to do nothing when
+# completions are available.
+zstyle ':completion:*' insert-tab false
 if (( ${+_comps[fzf-tab]} )); then
     zstyle ':fzf-tab:*' switch-group ',' '.'
     zstyle ':fzf-tab:*' show-group full


### PR DESCRIPTION
## Summary
- fix the `insert-tab` setting so tab completion shows candidates immediately

## Testing
- `./status.sh` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_687de9fb6614832b8d9358e364e686ec