### PR TITLE
Implement module color wrappers

### DIFF
--- a/modules/completion.zsh
+++ b/modules/completion.zsh
@@ -14,6 +14,10 @@ else
     color_green() { echo -e "\033[32m$1\033[0m"; }
 fi
 
+# Module specific wrappers
+comp_color_red()   { color_red "$@"; }
+comp_color_green() { color_green "$@"; }
+
 # -------------------- Completion Cache --------------------
 COMPLETION_CACHE_FILE="$ZSH_CACHE_DIR/zcompdump"
 autoload -Uz compinit

--- a/modules/core.zsh
+++ b/modules/core.zsh
@@ -14,6 +14,10 @@ else
     color_green() { echo -e "\033[32m$1\033[0m"; }
 fi
 
+# Module specific wrappers
+core_color_red()   { color_red "$@"; }
+core_color_green() { color_green "$@"; }
+
 # -------------------- Module Loading Status --------------------
 export ZSH_MODULES_LOADED=""
 

--- a/modules/keybindings.zsh
+++ b/modules/keybindings.zsh
@@ -14,6 +14,10 @@ else
     color_green() { echo -e "\033[32m$1\033[0m"; }
 fi
 
+# Module specific wrappers
+kb_color_red()   { color_red "$@"; }
+kb_color_green() { color_green "$@"; }
+
 # -------------------- Basic Editing/Navigation --------------------
 bindkey -e
 bindkey '^A' beginning-of-line


### PR DESCRIPTION
## Summary
- add module-specific color wrapper functions in `completion.zsh`
- add color wrapper functions to `core.zsh`
- add wrapper functions in `keybindings.zsh`

## Testing
- `./test.sh` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6882ecd0d480832bad742b5eade223c0