### PR TITLE
fix: update reload aliases

### DIFF
--- a/local.zsh
+++ b/local.zsh
@@ -41,9 +41,9 @@ reload_zshenv() {
 }
 
 # Aliases for reload functions
-alias r='zsh_reload'
+alias r='reload_source'
 alias rs='reload_source'
-alias rz='zsh_reload'
+alias rz='reload_source'
 alias rsenv='reload_zshenv'
 alias sz='source ~/.zshenv'
 


### PR DESCRIPTION
## Summary
- replace outdated `zsh_reload` aliases with `reload_source`

## Testing
- `bash ./test.sh` *(fails: Plugins module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ee0a25c8832ba5b8c1daf2b9377e