### PR TITLE
Deduplicate helper functions

### DIFF
--- a/local.zsh
+++ b/local.zsh
@@ -76,11 +76,6 @@ alias gco='git checkout'
 alias gb='git branch'
 
 # Add your personal functions here
-# Quick directory creation and navigation
-mkcd() {
-    mkdir -p "$1" && cd "$1"
-}
-
 # Extract various archive formats
 function extract() {
     if [ -f "$1" ]; then

--- a/modules/aliases.zsh
+++ b/modules/aliases.zsh
@@ -45,11 +45,7 @@ alias projects='cd ~/Projects' downloads='cd ~/Downloads' documents='cd ~/Docume
 alias now='date +"%T"' nowdate='date +"%d-%m-%Y"'
 
 # -------------------- High-Frequency Functions --------------------
-# Create directory and enter
-mkcd() {
-    [[ $# -eq 0 ]] && echo "Usage: mkcd <directory_name>" && return 1
-    mkdir -p "$1" && cd "$1"
-}
+# mkcd/myip helpers moved to utils.zsh
 # Quick directory navigation up
 up() {
     local levels=${1:-1} path=""
@@ -80,8 +76,7 @@ serve() {
     echo "Starting HTTP server: port $port, directory $dir"
     python3 -m http.server "$port" --directory "$dir"
 }
-# Get external IP
-myip() { curl -s ifconfig.me; }
+# External IP helper provided by utils.zsh
 # Quick git commit
 function gcm() {
     [[ $# -eq 0 ]] && echo "Usage: gcm <message>" && return 1

--- a/modules/utils.zsh
+++ b/modules/utils.zsh
@@ -17,6 +17,11 @@ backup() {
     cp "$file" "${file}.backup.$(date +%Y%m%d_%H%M%S)"
     color_green "Backed up: ${file}.backup.$(date +%Y%m%d_%H%M%S)"
 }
+# Create directory and enter
+mkcd() {
+    [[ $# -eq 0 ]] && echo "Usage: mkcd <directory_name>" && return 1
+    mkdir -p "$1" && cd "$1"
+}
 # Find files/directories
 ff() { [[ $# -eq 0 ]] && echo "Usage: ff <pattern>" && return 1; find . -name "*$1*" -type f 2>/dev/null; }
 fd() { [[ $# -eq 0 ]] && echo "Usage: fd <pattern>" && return 1; find . -name "*$1*" -type d 2>/dev/null; }


### PR DESCRIPTION
## Summary
- centralize `mkcd` and `myip` in `modules/utils.zsh`
- remove duplicate definitions from `modules/aliases.zsh` and `local.zsh`

## Testing
- `./test.sh` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6882f201add8832bb043d309681f39fe