### PR TITLE
Refactor color helpers usage

### DIFF
--- a/modules/completion.zsh
+++ b/modules/completion.zsh
@@ -5,14 +5,7 @@
 # =============================================================================
 
 # Color output tools
-# Load centralized color functions if available
-if [[ -f "$HOME/.config/zsh/modules/colors.zsh" ]]; then
-    source "$HOME/.config/zsh/modules/colors.zsh"
-else
-    # Fallback color functions
-    color_red()   { echo -e "\033[31m$1\033[0m"; }
-    color_green() { echo -e "\033[32m$1\033[0m"; }
-fi
+source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
 # Module specific wrappers
 comp_color_red()   { color_red "$@"; }

--- a/modules/core.zsh
+++ b/modules/core.zsh
@@ -5,14 +5,8 @@
 # =============================================================================
 
 # Color output tools
-# Load centralized color functions if available
-if [[ -f "$HOME/.config/zsh/modules/colors.zsh" ]]; then
-    source "$HOME/.config/zsh/modules/colors.zsh"
-else
-    # Fallback color functions
-    color_red()   { echo -e "\033[31m$1\033[0m"; }
-    color_green() { echo -e "\033[32m$1\033[0m"; }
-fi
+# Load centralized color functions
+source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
 # Module specific wrappers
 core_color_red()   { color_red "$@"; }

--- a/modules/keybindings.zsh
+++ b/modules/keybindings.zsh
@@ -5,14 +5,8 @@
 # =============================================================================
 
 # Color output tools
-# Load centralized color functions if available
-if [[ -f "$HOME/.config/zsh/modules/colors.zsh" ]]; then
-    source "$HOME/.config/zsh/modules/colors.zsh"
-else
-    # Fallback color functions
-    color_red()   { echo -e "\033[31m$1\033[0m"; }
-    color_green() { echo -e "\033[32m$1\033[0m"; }
-fi
+# Load centralized color functions
+source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
 # Module specific wrappers
 kb_color_red()   { color_red "$@"; }

--- a/modules/plugins.zsh
+++ b/modules/plugins.zsh
@@ -5,14 +5,8 @@
 # =============================================================================
 
 # Color output tools
-# Load centralized color functions if available
-if [[ -f "$HOME/.config/zsh/modules/colors.zsh" ]]; then
-    source "$HOME/.config/zsh/modules/colors.zsh"
-else
-    # Fallback color functions
-    color_red()   { echo -e "\033[31m$1\033[0m"; }
-    color_green() { echo -e "\033[32m$1\033[0m"; }
-fi
+# Load centralized color functions
+source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
 # -------------------- zinit Installation and Loading --------------------
 if [[ -z "$ZINIT" ]]; then

--- a/modules/utils.zsh
+++ b/modules/utils.zsh
@@ -5,8 +5,7 @@
 # =============================================================================
 
 # Color output tools
-color_red()   { echo -e "\033[31m$1\033[0m"; }
-color_green() { echo -e "\033[32m$1\033[0m"; }
+source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
 # -------------------- File/Directory Operations --------------------
 # Backup file


### PR DESCRIPTION
## Summary
- centralize color logging helpers via `modules/colors.zsh`
- source color helpers unconditionally in each module

## Testing
- `zsh -n modules/*.zsh` *(fails: `zsh` not installed)*
- `./test.sh` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6882f3a5bf1c832ba224c73c67426a6c