### PR TITLE
Improve alias conflict detection

### DIFF
--- a/modules/plugins.zsh
+++ b/modules/plugins.zsh
@@ -239,7 +239,7 @@ check_plugin_conflicts() {
     fi
 
     # Check for alias conflicts
-    local alias_conflicts=$(alias | awk '{print $1}' | sort | uniq -d)
+    local alias_conflicts=$(alias | cut -d= -f1 | sed 's/^alias //g' | sort | uniq -d)
     if [[ -n "$alias_conflicts" ]]; then
         echo "❌ Duplicate aliases found:"
         echo "$alias_conflicts" | sed 's/^/   • /'
@@ -305,7 +305,7 @@ resolve_plugin_conflicts() {
     fi
 
     # Check for alias conflicts
-    local duplicate_aliases=$(alias | awk '{print $1}' | sort | uniq -d)
+    local duplicate_aliases=$(alias | cut -d= -f1 | sed 's/^alias //g' | sort | uniq -d)
     if [[ -n "$duplicate_aliases" ]]; then
         echo "💡 Alias conflict resolution suggestions:"
         echo "$duplicate_aliases" | while read -r alias_name; do

--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ fi
 # Test 2: Check for duplicate aliases
 echo ""
 echo "2️⃣  Checking aliases..."
-duplicate_aliases=$(alias | awk '{print $1}' | sort | uniq -d)
+duplicate_aliases=$(alias | cut -d= -f1 | sed 's/^alias //g' | sort | uniq -d)
 if [[ -n "$duplicate_aliases" ]]; then
     error "Duplicate aliases found:"
     echo "$duplicate_aliases" | sed 's/^/  • /'


### PR DESCRIPTION
## Summary
- update alias detection logic to parse alias names correctly
- adjust tests to use new alias extraction method

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `./test.sh` *(fails: `/usr/bin/env: 'zsh': No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6882f3a1f088832b95c8cfae887c3571