### PR TITLE
Improve plugin management and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ High-performance, modular ZSH configuration system optimized for personal work e
 ## 📋 System Requirements
 
 ### Required Dependencies
-- **ZSH**: Version 5.8 or higher
+- **ZSH**: Version 5.8 or higher (the configuration checks this on startup)
 - **Git**: For plugin management
 
 ### Optional Dependencies (Recommended)
@@ -271,6 +271,8 @@ config env      # 编辑环境配置
 本项目采用简化的环境变量配置方式：
 - **核心环境变量**：在 `zshenv` 中直接设置（XDG路径、ZSH路径、历史记录等）
 - **插件环境变量**：在 `modules/plugins.zsh` 中管理（ZSH自动建议配置等）
+- `ZSH_ENABLE_PLUGINS` 控制是否加载所有插件
+- `ZSH_ENABLE_OPTIONAL_PLUGINS` 控制可选插件（如 fzf-tab）
 - **主题环境变量**：在 `themes/prompt.zsh` 中管理（Oh My Posh配置等）
 - **用户环境变量**：使用模板化管理（开发工具路径、包管理器镜像等）
 

--- a/env/README.md
+++ b/env/README.md
@@ -30,6 +30,8 @@ env/
 ### 2. 插件环境变量（在modules/plugins.zsh中管理）
 - ZSH自动建议配置
 - 其他插件相关配置
+- `ZSH_ENABLE_PLUGINS`：是否加载所有插件（1/0）
+- `ZSH_ENABLE_OPTIONAL_PLUGINS`：是否加载可选插件（如fzf-tab）
 
 ### 3. 主题环境变量（在themes/prompt.zsh中管理）
 - Oh My Posh配置

--- a/env/templates/environment.env.template
+++ b/env/templates/environment.env.template
@@ -54,6 +54,11 @@ export FLUTTER_STORAGE_BASE_URL="https://storage.flutter-io.cn"
 # 说明: 在此区域添加你的自定义环境变量
 # =============================================================================
 
+# Toggle plugin loading (1=enabled, 0=disabled)
+export ZSH_ENABLE_PLUGINS=1
+# Toggle optional plugins like fzf-tab
+export ZSH_ENABLE_OPTIONAL_PLUGINS=1
+
 # 用户本地二进制文件路径
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/modules/plugins.zsh
+++ b/modules/plugins.zsh
@@ -8,6 +8,10 @@
 # Load centralized color functions
 source "$ZSH_CONFIG_DIR/modules/colors.zsh"
 
+# Allow disabling plugins via environment variables
+: "${ZSH_ENABLE_PLUGINS:=1}"
+: "${ZSH_ENABLE_OPTIONAL_PLUGINS:=1}"
+
 # -------------------- Plugin Initialization --------------------
 plugin_init() {
     [[ -n "$ZINIT" ]] && return
@@ -39,6 +43,8 @@ typeset -ga BUILTIN_SNIPPETS=(
 )
 
 plugins_load() {
+    (( ZSH_ENABLE_PLUGINS )) || { color_yellow "Plugins disabled via ZSH_ENABLE_PLUGINS=0"; return; }
+
     plugin_init
     [[ ! -o interactive ]] && return
 
@@ -51,7 +57,7 @@ plugins_load() {
         zinit snippet "$snip"
     done
 
-    if command -v fzf >/dev/null 2>&1; then
+    if (( ZSH_ENABLE_OPTIONAL_PLUGINS )) && command -v fzf >/dev/null 2>&1; then
         for p in "${OPTIONAL_ZINIT_PLUGINS[@]}"; do
             zinit ice wait"0" lucid
             zinit light "$p" 2>/dev/null || true
@@ -60,6 +66,7 @@ plugins_load() {
 }
 
 plugins_update() {
+    (( ZSH_ENABLE_PLUGINS )) || { color_yellow "Plugins disabled. Skip update"; return; }
     plugin_init
     zinit self-update && zinit update --all
 }

--- a/status.sh
+++ b/status.sh
@@ -4,14 +4,28 @@
 # Version: 4.3 - Enhanced Beautiful Output
 # =============================================================================
 
-# Enhanced color functions for beautiful output
-status_color_red()    { echo -e "\033[31m$1\033[0m"; }
-status_color_green()  { echo -e "\033[32m$1\033[0m"; }
-status_color_yellow() { echo -e "\033[33m$1\033[0m"; }
-status_color_blue()   { echo -e "\033[34m$1\033[0m"; }
-status_color_purple() { echo -e "\033[35m$1\033[0m"; }
-status_color_cyan()   { echo -e "\033[36m$1\033[0m"; }
-status_color_bold()   { echo -e "\033[1m$1\033[0m"; }
+# Load shared color functions
+ZSH_CONFIG_DIR="${ZSH_CONFIG_DIR:-$HOME/.config/zsh}"
+if [[ -f "$ZSH_CONFIG_DIR/modules/colors.zsh" ]]; then
+    source "$ZSH_CONFIG_DIR/modules/colors.zsh"
+else
+    color_red()    { echo -e "\033[31m$1\033[0m"; }
+    color_green()  { echo -e "\033[32m$1\033[0m"; }
+    color_yellow() { echo -e "\033[33m$1\033[0m"; }
+    color_blue()   { echo -e "\033[34m$1\033[0m"; }
+    color_magenta(){ echo -e "\033[35m$1\033[0m"; }
+    color_cyan()   { echo -e "\033[36m$1\033[0m"; }
+    color_bold()   { echo -e "\033[1m$1\033[0m"; }
+fi
+
+# Local wrappers for status script
+status_color_red()    { color_red "$@"; }
+status_color_green()  { color_green "$@"; }
+status_color_yellow() { color_yellow "$@"; }
+status_color_blue()   { color_blue "$@"; }
+status_color_purple() { color_magenta "$@"; }
+status_color_cyan()   { color_cyan "$@"; }
+status_color_bold()   { color_bold "$@"; }
 status_color_dim()    { echo -e "\033[2m$1\033[0m"; }
 
 # Progress indicator function

--- a/zshrc
+++ b/zshrc
@@ -7,6 +7,12 @@
 # Set ZSH configuration root directory (compatible with direct calls)
 export ZSH_CONFIG_DIR="${ZSH_CONFIG_DIR:-$HOME/.config/zsh}"
 
+# Minimum required version
+autoload -Uz is-at-least
+if ! is-at-least 5.8 $ZSH_VERSION; then
+    echo "[zshrc] Warning: ZSH 5.8+ recommended. Current: $ZSH_VERSION" >&2
+fi
+
 # Load environment variables first (core environment setup)
 if [[ -f "$ZSH_CONFIG_DIR/zshenv" ]]; then
     source "$ZSH_CONFIG_DIR/zshenv"


### PR DESCRIPTION
## Summary
- allow disabling plugins via environment variables
- add zsh version check in `zshrc`
- source common color utilities in status script
- document plugin toggle variables

## Testing
- `./test.sh` *(fails: `/usr/bin/env: ‘zsh’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6886e1883bc0832bbfe1c9c35808d971