### PR TITLE
Fix README conflicts and improve project checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,8 @@
 ## 🔧 System Requirements
 
 ### Required Dependencies
-<<<<<<< HEAD
-- **ZSH**: Version 5.8 or higher
+- **ZSH**: Version 5.8 or higher (checked on startup)
 - **Git**: For plugin management and updates
-=======
-- **ZSH**: Version 5.8 or higher (the configuration checks this on startup)
-- **Git**: For plugin management
->>>>>>> ac16eed89bb6d528f3565da520287a46f6fd429e
 
 ### Optional Dependencies (Recommended)
 - **fzf**: Fuzzy file finder
@@ -172,10 +167,8 @@ export PATH="$HOME/.local/bin:$PATH"
 
 ### Custom Configuration
 
-<<<<<<< HEAD
-Create `~/.config/zsh/custom/local.zsh` for personal settings:
-=======
-### 自定义配置
+Create `~/.config/zsh/custom/local.zsh` for personal settings. You can also use the helper commands to edit modules:
+
 ```bash
 config zshrc    # 编辑主配置
 config core     # 编辑核心模块
@@ -225,7 +218,6 @@ ${EDITOR:-code} ~/.config/zsh/env/local/environment.env
 
 #### 故障排除
 如果配置更改后没有生效，可能的原因和解决方案：
->>>>>>> ac16eed89bb6d528f3565da520287a46f6fd429e
 
 ```bash
 # Personal aliases

--- a/check-project.sh
+++ b/check-project.sh
@@ -4,7 +4,7 @@
 # Comprehensive project validation and health check
 # =============================================================================
 
-set -euo pipefail
+set -uo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -37,22 +37,22 @@ run_test() {
     local test_name="$1"
     local test_command="$2"
     local description="${3:-}"
-    
+
     ((TOTAL_TESTS++))
-    
-    if eval "$test_command" >/dev/null 2>&1; then
+
+    set +e
+    eval "$test_command" >/dev/null 2>&1
+    local result=$?
+
+    if [[ $result -eq 0 ]]; then
         ((PASSED_TESTS++))
         success "$test_name"
-        if [[ -n "$description" ]]; then
-            echo "    $description"
-        fi
+        [[ -n "$description" ]] && echo "    $description"
         return 0
     else
         ((FAILED_TESTS++))
         error "$test_name"
-        if [[ -n "$description" ]]; then
-            echo "    $description"
-        fi
+        [[ -n "$description" ]] && echo "    $description"
         return 1
     fi
 }
@@ -61,22 +61,22 @@ run_warning_test() {
     local test_name="$1"
     local test_command="$2"
     local description="${3:-}"
-    
+
     ((TOTAL_TESTS++))
-    
-    if eval "$test_command" >/dev/null 2>&1; then
+
+    set +e
+    eval "$test_command" >/dev/null 2>&1
+    local result=$?
+
+    if [[ $result -eq 0 ]]; then
         ((PASSED_TESTS++))
         success "$test_name"
-        if [[ -n "$description" ]]; then
-            echo "    $description"
-        fi
+        [[ -n "$description" ]] && echo "    $description"
         return 0
     else
         ((WARNINGS++))
         warning "$test_name"
-        if [[ -n "$description" ]]; then
-            echo "    $description"
-        fi
+        [[ -n "$description" ]] && echo "    $description"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- fix merge conflicts in README
- document helper commands for custom config
- make check-project more resilient to failing tests

## Testing
- `./check-project.sh > /tmp/check.log`
- `./test.sh unit` *(fails: zsh is required but not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886e735f148832ba39825a68011f000