### PR TITLE
Fix oh-my-posh install in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
           sudo apt install -y fzf zoxide eza
           
           # Install oh-my-posh
-          wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
-          chmod +x /usr/local/bin/oh-my-posh
+          sudo wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
+          sudo chmod +x /usr/local/bin/oh-my-posh
           
       - name: Run installation script
         run: |


### PR DESCRIPTION
## Summary
- fix permissions for oh-my-posh install in GitHub workflow

## Testing
- `bash check-project.sh` *(fails: output truncated)*
- `zsh test.sh all` *(fails: `zsh: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68898062b398832baed26f44be2a44ae