### PR TITLE
Fix ShellCheck SC2168 errors

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -43,6 +43,7 @@ show_progress() {
     printf "] %d%%" $((current * 100 / total))
 }
 
+main() {
 # Load configuration with progress
 echo
 status_color_bold "╔══════════════════════════════════════════════════════════════╗"
@@ -286,3 +287,6 @@ status_color_green "✅ Status check completed successfully!"
 status_color_cyan "   Your ZSH configuration is ready to use."
 status_color_dim "   Generated at $(date '+%Y-%m-%d %H:%M:%S')"
 echo
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- wrap status script logic in a `main` function
- call `main` at the end

## Testing
- `bash check-project.sh` *(fails: no output)*
- `./test.sh unit` *(fails: `zsh` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6889949b5f3c832b97e76e4ffb30fd49