### PR TITLE
Fix ShellCheck workflow inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,12 +267,12 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       with:
         severity: warning
-        shell: bash
-        ignore_paths: >-
-          themes/*
-          modules/*
-          completions/*
-          env/*
+        ignore_paths: |
+          themes/
+          modules/
+          completions/
+          env/
+        ignore_names: |
           zshrc
           zshenv
           *.zsh


### PR DESCRIPTION
## Summary
- remove invalid `shell` input from ShellCheck step
- adjust ignore settings to filter out ZSH-specific files

## Testing
- `bash check-project.sh --help`
- `bash check-project.sh` *(fails: missing dependencies)*
- `./test.sh unit` *(fails: zsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688c2bce66dc832b853b41a23a80a5f4