### PR TITLE
Remove oh-my-zsh references

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -305,7 +305,7 @@ run_plugin_tests() {
     test_section "Plugin Tests"
     
     # Test if plugin manager is available
-    local plugin_managers=("zinit" "zplug" "antigen" "oh-my-zsh")
+    local plugin_managers=("zinit" "zplug" "antigen")
     local found_manager=""
     
     for manager in "${plugin_managers[@]}"; do
@@ -329,6 +329,13 @@ run_plugin_tests() {
             test_skip "Plugin directory exists: $(basename "$dir")" "Plugin directory not found"
         fi
     done
+
+    # Test if Oh My Posh is available
+    if command -v oh-my-posh >/dev/null 2>&1; then
+        test_assert "oh-my-posh is available" "true" "oh-my-posh not available"
+    else
+        test_skip "oh-my-posh is available" "oh-my-posh not installed"
+    fi
 }
 
 # Conflict Tests

--- a/themes/prompt.zsh
+++ b/themes/prompt.zsh
@@ -42,7 +42,7 @@ if command -v oh-my-posh >/dev/null 2>&1; then
     # eval "$(oh-my-posh init zsh --config ~/.poshthemes/jandedobbeleer.omp.json)" # Author's theme
     # eval "$(oh-my-posh init zsh --config ~/.poshthemes/m365princess.omp.json)"   # Princess theme
     # eval "$(oh-my-posh init zsh --config ~/.poshthemes/paradox.omp.json)"       # Paradox theme
-    # eval "$(oh-my-posh init zsh --config ~/.poshthemes/robbyrussell.omp.json)"  # Oh My Zsh style
+    # eval "$(oh-my-posh init zsh --config ~/.poshthemes/robbyrussell.omp.json)"  # Robby Russell classic style
     # eval "$(oh-my-posh init zsh --config ~/.poshthemes/star.omp.json)"          # Star theme
     # eval "$(oh-my-posh init zsh --config ~/.poshthemes/tokyonight.omp.json)"    # Tokyo Night
 else


### PR DESCRIPTION
## Summary
- drop leftover Oh My Zsh plugin manager entry and add check for Oh My Posh presence in plugin tests
- clarify theme comment to use Robby Russell classic style wording

## Testing
- `./test.sh plugins` *(fails: test.sh must be run with zsh but zsh is not installed or not in PATH)*
- `apt-get update` *(fails: repository ... is not signed / 403 Forbidden)*
- `apt-get install -y zsh` *(fails: Unable to locate package zsh)*
- `./check-project.sh`


------
https://chatgpt.com/codex/tasks/task_e_689964c8a390832b8912710cc34bae39