### PR TITLE
Fix check script counters and main invocation

### DIFF
--- a/check-project.sh
+++ b/check-project.sh
@@ -39,10 +39,10 @@ run_test() {
     local description="${3:-}"
     local critical="${4:-false}"
     
-    ((TOTAL_TESTS++))
+    ((++TOTAL_TESTS))
     
     if eval "$test_command" >/dev/null 2>&1; then
-        ((PASSED_TESTS++))
+        ((++PASSED_TESTS))
         success "$test_name"
         if [[ -n "$description" ]]; then
             echo "    $description"
@@ -50,14 +50,14 @@ run_test() {
         return 0
     else
         if [[ "$critical" == "true" ]]; then
-            ((FAILED_TESTS++))
+            ((++FAILED_TESTS))
             error "$test_name"
             if [[ -n "$description" ]]; then
                 echo "    $description"
             fi
             return 1
         else
-            ((WARNINGS++))
+            ((++WARNINGS))
             warning "$test_name"
             if [[ -n "$description" ]]; then
                 echo "    $description"
@@ -73,17 +73,17 @@ run_warning_test() {
     local test_command="$2"
     local description="${3:-}"
     
-    ((TOTAL_TESTS++))
+    ((++TOTAL_TESTS))
     
     if eval "$test_command" >/dev/null 2>&1; then
-        ((PASSED_TESTS++))
+        ((++PASSED_TESTS))
         success "$test_name"
         if [[ -n "$description" ]]; then
             echo "    $description"
         fi
         return 0
     else
-        ((WARNINGS++))
+        ((++WARNINGS))
         warning "$test_name"
         if [[ -n "$description" ]]; then
             echo "    $description"
@@ -354,4 +354,4 @@ case "${1:-}" in
 esac
 
 # Run main function
-main "$@" 
+main "$@"

--- a/status.sh
+++ b/status.sh
@@ -154,14 +154,11 @@ else
 fi
 
 # Check if modules are loaded by looking for module-specific indicators
-local modules_loaded=false
 if [[ -n "$ZSH_MODULES_LOADED" ]]; then
-    modules_loaded=true
     printf "    %s %s\n" "✅" "$(status_color_green "Modules loaded: $ZSH_MODULES_LOADED")"
 else
     # Fallback: check if key module functions exist
     if (( ${+functions[color_green]} )) || (( ${+functions[color_red]} )); then
-        modules_loaded=true
         printf "    %s %s\n" "✅" "$(status_color_green "Modules loaded (detected via functions)")"
     else
         printf "    %s %s\n" "❌" "$(status_color_red "No modules loaded")"


### PR DESCRIPTION
## Summary
- Convert post-increment counters in `check-project.sh` to pre-increments so `set -e` doesn’t terminate the health check
- Remove stray prompt text to ensure `main "$@"` runs cleanly

## Testing
- `./test.sh` *(fails: zsh is not installed)*
- `apt-get update` *(fails: repository is not signed)*
- `./check-project.sh`

------
https://chatgpt.com/codex/tasks/task_e_689987427620832b9cb4d6861e00f209