### PR TITLE
fix(prompt): suppress xtrace candidate noise during theme initialization

### DIFF
--- a/themes/prompt.zsh
+++ b/themes/prompt.zsh
@@ -86,6 +86,11 @@ _clean_prompt() {
 # Initialize prompt system
 _init_prompt_system() {
     setopt local_options no_xtrace 2>/dev/null
+    local restore_xtrace=0
+    if [[ "${options[xtrace]}" == "on" ]]; then
+        restore_xtrace=1
+        unsetopt xtrace
+    fi
     # Register cleanup hook
     autoload -Uz add-zsh-hook 2>/dev/null
     add-zsh-hook precmd _clean_prompt 2>/dev/null
@@ -157,6 +162,8 @@ _init_prompt_system() {
         PROMPT='%F{green}%n@%m%f:%F{cyan}%~%f${vcs_info_msg_0_} %# '
         RPROMPT='%F{yellow}[%D{%H:%M:%S}]%f'
     fi
+
+    (( restore_xtrace )) && setopt xtrace
 }
 
 # Initialize the prompt system

--- a/themes/prompt.zsh
+++ b/themes/prompt.zsh
@@ -49,6 +49,11 @@ typeset -g POSH_THEME_PREF_FILE="${POSH_THEME_PREF_FILE:-$ZSH_CONFIG_DIR/themes/
 _posh_resolve_theme_name() {
     local name="$1"
     [[ -z "$name" ]] && return 1
+    # Prevent path traversal and shell metacharacters in theme names.
+    # Accept only plain theme tokens with optional .omp.(json|yaml) suffix.
+    if [[ ! "$name" =~ '^[A-Za-z0-9._-]+(\.omp\.(json|yaml))?$' ]]; then
+        return 1
+    fi
     if [[ "$name" == *.omp.json || "$name" == *.omp.yaml ]]; then
         echo "$name"
     else
@@ -110,11 +115,11 @@ _init_prompt_system() {
         )
         local saved_theme=""
         if [[ -n "${ZSH_POSH_THEME:-}" ]]; then
-            saved_theme="$(_posh_resolve_theme_name "$ZSH_POSH_THEME")"
+            saved_theme="$(_posh_resolve_theme_name "$ZSH_POSH_THEME")" || saved_theme=""
         elif [[ -f "$POSH_THEME_PREF_FILE" ]]; then
             local pref_content
             pref_content="$(head -n1 "$POSH_THEME_PREF_FILE" 2>/dev/null | tr -d '[:space:]')"
-            [[ -n "$pref_content" ]] && saved_theme="$(_posh_resolve_theme_name "$pref_content")"
+            [[ -n "$pref_content" ]] && saved_theme="$(_posh_resolve_theme_name "$pref_content")" || saved_theme=""
         fi
 
         if [[ -n "$saved_theme" ]]; then


### PR DESCRIPTION
### Motivation
- Prevent repeated `candidate=''` lines printed at startup when an inherited `xtrace`/`set -x` state from the environment causes theme discovery to emit spurious output, while preserving intentional debug tracing for users.

### Description
- Add a temporary `xtrace` guard in `_init_prompt_system` inside `themes/prompt.zsh` that detects `options[xtrace]`, `unsetopt xtrace` during theme initialization, and restores it afterward if it was previously enabled.

### Testing
- Attempted static checks with `zsh -n themes/prompt.zsh` and `zsh -n zshrc` and ran `./test.sh validation`, but these could not be executed in this environment because `zsh` is not installed, so no runtime tests were completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a8851f484832b918ef0ac57553a88)